### PR TITLE
 feat: hexagon support

### DIFF
--- a/styx/core/styx-cpu-pcode-backend/src/arch_spec/hexagon/dotnew.rs
+++ b/styx/core/styx-cpu-pcode-backend/src/arch_spec/hexagon/dotnew.rs
@@ -24,9 +24,11 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use log::trace;
 
+use crate::arch_spec::hexagon::parse_iclass;
+
 // This may require some extra stuff
 pub fn parse_dotnew(insn: u32) -> Option<u32> {
-    let iclass = (insn >> 28) & 0xf;
+    let iclass = parse_iclass(insn);
 
     // want bits 27 to 21
     let insn_0011_type = (insn >> 21) & 0b1111111;

--- a/styx/core/styx-cpu-pcode-backend/src/arch_spec/hexagon/helpers.rs
+++ b/styx/core/styx-cpu-pcode-backend/src/arch_spec/hexagon/helpers.rs
@@ -35,6 +35,8 @@ use styx_pcode_translator::ContextOption;
 use styx_processor::cpu::CpuBackendExt;
 use styx_processor::{cpu::CpuBackend, memory::Mmu};
 
+use super::parse_iclass;
+
 // How many insns to fetch to analyze for duplexes?
 // Is trapping easier?
 // this will be used later if there are performance issues with the current solution
@@ -200,6 +202,14 @@ impl HexagonGeneratorHelperState {
 }
 
 impl HexagonGeneratorHelper {
+    fn handle_dotnew_immext(&mut self, insn_data: u32, backend: &mut PcodeBackend) {
+        // I think I need a separate "parse_iclass function"
+        let iclass = parse_iclass(insn_data);
+        let is_immext = iclass == 0b0000;
+        backend
+            .shared_state
+            .insert(SharedStateKey::HexagonCurrentInsnImmext, is_immext as u128);
+    }
     fn handle_dotnew(
         &mut self,
         insn_data: u32,
@@ -486,6 +496,8 @@ impl GeneratorHelp for HexagonGeneratorHelper {
                         let parse_next = PktLoopParseBits::new_from_insn(insn_next);
                         let _parse_next1 = PktLoopParseBits::new_from_insn(insn_next1);
                         let _parse_next2 = PktLoopParseBits::new_from_insn(insn_next2);
+
+                        self.handle_dotnew_immext(insn_data, backend);
 
                         self.state.handle_duplex_immext(
                             parse_next,

--- a/styx/core/styx-cpu-pcode-backend/src/arch_spec/hexagon/mod.rs
+++ b/styx/core/styx-cpu-pcode-backend/src/arch_spec/hexagon/mod.rs
@@ -44,6 +44,10 @@ pub use pc_manager::StandardPcManager;
 use pkt_semantics::NewReg;
 use styx_pcode_translator::sla::{self, HexagonUserOps};
 
+fn parse_iclass(insn: u32) -> u32 {
+    (insn >> 28) & 0xf
+}
+
 // Adapted from PPC
 pub fn build() -> ArchSpecBuilder<sla::Hexagon> {
     let mut spec = ArchSpecBuilder::default();

--- a/styx/core/styx-cpu-pcode-backend/src/lib.rs
+++ b/styx/core/styx-cpu-pcode-backend/src/lib.rs
@@ -169,6 +169,8 @@ pub enum SharedStateKey {
     HexagonTrueInsnCount,
     // Stores destination register in an instruction
     HexagonInsnRegDest(usize),
+    // Is the current instruction immext?
+    HexagonCurrentInsnImmext,
 }
 
 #[derive(Derivative)]
@@ -199,13 +201,11 @@ pub struct PcodeBackend {
     // we could use an enum with the previous map but it's easier to just
     // make a separate saved context
     saved_shared_state_context: FxHashMap<SharedStateKey, u128>,
-    // TODO: what about the generator helper?
     saved_pc_manager: Option<PcManager>,
     saved_generator_helper: Option<Box<GeneratorHelper>>,
     // we may want to make this an enum dispatch at some point,
     // and u128 is chosen to avoid space issues with storing
     // registers that may be different sizes on different platforms
-    // TODO: does this have to be dealt with in context switches?
     pub shared_state: FxHashMap<SharedStateKey, u128>,
 }
 


### PR DESCRIPTION
wip at the moment

tasks:

- [x] initial isa support on the styx side
- [x] initial variants added
- [x] pcode backend support from the slaspec
- [x] basic insn tests to ensure things are going
    - [x] single instructions
    - [x] unconditional branching
    - [x] conditional branching
    - [x] duplex
    - [x] immediate extension - regular instruction
    - [x] immediate extension - duplex
    - [x] hardware loop
    - [x] hardware loop - nested
    - [x] dotnew - predicate
    - [x] dotnew - store
    - [x] compound instructions
    - [ ] register postfixes (maybe a separate issue)
    - [ ] stub system instructions
- [ ] registers
    - [ ] usr register (handle when system insns are done)
    - [x] 32 bit register pairs
    - [x] vector register pairs (do we care about this now?) (stubbed)
- [ ] ensure that context save/restore works (NEEDS UNIT TESTS)
    - [ ] pcode backend pcmanager for hexagon needs to be able to handle instruction packet semantics

At some point (this should wait to see how much refactoring needs to be done once things work instead of preemptively cleaning):

- [ ] clean up generator helper (potentially by precomputing all context options for a packet at first packet)

Things we need to know:

- [x] How often do packet semantics affect packet execution?
    - in a firmware, figure out how many packets have states that could corrupt output register / memory writes etc

(what are part1/part2 context registers used for?)
