### PR TITLE
feat: TLB translate_va takes a &mut dyn CpuBackend  + TLB exceptions in cpu backend

### DIFF
--- a/styx/core/styx-cpu-pcode-backend/src/execute_pcode.rs
+++ b/styx/core/styx-cpu-pcode-backend/src/execute_pcode.rs
@@ -209,6 +209,9 @@ fn execute_pcode_inner<'a>(
                         }
                     }
                 }
+                Err(VarnodeError::SpaceError(SpaceError::MemoryError(
+                    MmuOpError::TlbException(exception_number),
+                ))) => Err(PCodeStateChange::Exception(exception_number)),
 
                 Err(e) => panic!("unexpected varnode error \n{e:?}"),
             };
@@ -361,6 +364,9 @@ fn execute_pcode_inner<'a>(
                         }
                     }
                 }
+                Err(VarnodeError::SpaceError(SpaceError::MemoryError(
+                    MmuOpError::TlbException(exception_number),
+                ))) => PCodeStateChange::Exception(exception_number).into(),
 
                 Err(e) => panic!("unexpected varnode error \n{e:?}"),
             }

--- a/styx/core/styx-cpu-pcode-backend/src/lib.rs
+++ b/styx/core/styx-cpu-pcode-backend/src/lib.rs
@@ -65,6 +65,8 @@ pub(crate) enum PCodeStateChange {
     InstructionAbsolute(u64),
     /// a relative jump to a pcode op within the current translation
     PCodeRelative(i64),
+    /// Trigger interrupt as soon as possible. This is used for a TLB exception.
+    Exception(i32),
     Exit(TargetExitReason),
 }
 
@@ -135,6 +137,21 @@ fn handle_basic_block_hooks(
     Ok(())
 }
 
+/// The Pcode Cpu Backend
+///
+/// # Behaviors
+///
+/// ## Exceptions
+///
+/// Currently, the only exceptions implemented are the ones thrown by the
+/// [TLB](styx_processor::memory::TlbImpl) (see
+/// [TlbTranslateError::Exception](styx_processor::memory::TlbTranslateError::Exception)). When the
+/// TLB indicates an exception, the rest of the pcodes in the instruction are not run and an
+/// interrupt hook is triggered with the exception number give by the TLB. The Pc is not
+/// incremented. It is expected that the interrupt hook handles the TLB exception as required by the
+/// processor manual. With no intervention, the instruction will be run again, possibly throwing the
+/// same TLB exception.
+///
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct PcodeBackend {
@@ -301,9 +318,18 @@ impl PcodeBackend {
 
         // fetch_pcode handles triggering hooks based on exception handler
         // Err(exit_reason) indicates an exception makes us pause so we should honor that
-        let bytes_consumed = match fetch_pcode(self, pcodes, mmu, ev)? {
+        let bytes_consumed = match fetch_pcode(self, pcodes, mmu, ev) {
             Ok(success) => success,
-            Err(exit) => return Ok(Err(exit)),
+            Err(err) => match err {
+                get_pcode::FetchPcodeError::TargetExit(target_exit_reason) => {
+                    return Ok(Err(target_exit_reason))
+                }
+                get_pcode::FetchPcodeError::TlbException(irqn) => {
+                    HookManager::trigger_interrupt_hook(self, mmu, ev, irqn)?;
+                    return Ok(Ok(0));
+                }
+                get_pcode::FetchPcodeError::Other(error) => return Err(error),
+            },
         };
 
         let mut pc_manager = self.pc_manager.take().unwrap();
@@ -349,6 +375,12 @@ impl PcodeBackend {
                     pc_manager.set_internal_pc(new_pc, self);
                     self.pc_manager = Some(pc_manager);
                     return Ok(Ok(bytes_consumed)); // Don't increment PC, jump to next instruction
+                }
+                PCodeStateChange::Exception(irqn) => {
+                    // exception occurred
+                    // we should interrupt hook and rerun instruction
+                    HookManager::trigger_interrupt_hook(self, mmu, ev, irqn)?;
+                    return Ok(Ok(bytes_consumed)); // Don't increment PC
                 }
                 PCodeStateChange::Exit(reason) => return Ok(Err(reason)),
             }

--- a/styx/core/styx-cpu-pcode-backend/tests/virtual_addressing.rs
+++ b/styx/core/styx-cpu-pcode-backend/tests/virtual_addressing.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 use log::info;
+use std::sync::{Arc, Mutex};
 use styx_cpu_pcode_backend::PcodeBackend;
 use styx_cpu_type::{
     arch::ppc32::{Ppc32Register, Ppc32Variants},
@@ -8,13 +9,14 @@ use styx_cpu_type::{
 use styx_errors::UnknownError;
 use styx_processor::{
     cpu::{CpuBackend, CpuBackendExt},
-    event_controller::EventController,
+    event_controller::{EventController, ExceptionNumber},
+    hooks::{CoreHandle, Hookable, StyxHook},
     memory::{
         helpers::{ReadExt, WriteExt},
         memory_region::MemoryRegion,
         physical::PhysicalMemoryVariant,
         ClosureTlb, MemoryOperation, MemoryPermissions, MemoryType, Mmu, TlbProcessor,
-        TlbTranslateResult,
+        TlbTranslateError, TlbTranslateResult,
     },
 };
 use styx_util::logging::init_logging;
@@ -28,6 +30,7 @@ fn tlb_translate_plus_0x1000(
 ) -> TlbTranslateResult {
     info!("getting addr 0x{virtual_addr:X}");
 
+    // make sure reading registers works in here
     let reg_value = processor
         .cpu
         .read_register::<u32>(Ppc32Register::R1)
@@ -105,6 +108,176 @@ fn test_virtual_write() -> Result<(), UnknownError> {
 
     let written_value = mmu.virt_data(&mut cpu).read(0x1000).be().u32()?;
     assert_eq!(4919, written_value);
+
+    Ok(())
+}
+
+fn tlb_translate_exception(
+    virtual_addr: u64,
+    _operation: MemoryOperation,
+    _memory_type: MemoryType,
+    processor: &mut TlbProcessor,
+) -> TlbTranslateResult {
+    info!("getting addr 0x{virtual_addr:X}");
+
+    // make sure reading registers works in here
+    let reg_value = processor
+        .cpu
+        .read_register::<u32>(Ppc32Register::R1)
+        .unwrap();
+    info!("got reg value {reg_value}");
+
+    Err(TlbTranslateError::Exception(0x1337))
+}
+
+/// Test hitting a tlb exception.
+#[test]
+fn test_virtual_fetch_exception() -> Result<(), UnknownError> {
+    init_logging();
+
+    let mut cpu =
+        PcodeBackend::new_engine(Arch::Ppc32, Ppc32Variants::Ppc405, ArchEndian::BigEndian);
+    let physical_memory = PhysicalMemoryVariant::RegionStore;
+    let tlb = ClosureTlb::new(Box::new(tlb_translate_exception));
+    let mut mmu = Mmu::new(Box::new(tlb), physical_memory, &mut cpu)?;
+    let mut ev = EventController::default();
+
+    mmu.add_memory_region(MemoryRegion::new(0, 0x3000, MemoryPermissions::all())?)
+        .unwrap();
+
+    let last_irq: Arc<Mutex<Option<ExceptionNumber>>> = Arc::new(Mutex::new(None));
+    {
+        let last_irq = last_irq.clone();
+        cpu.add_hook(StyxHook::interrupt(move |_cpu: CoreHandle, irqn| {
+            *last_irq.lock().unwrap() = Some(irqn);
+            Ok(())
+        }))?;
+    }
+
+    cpu.execute(&mut mmu, &mut ev, 3)?;
+
+    let irq = last_irq.lock().unwrap().unwrap();
+    assert_eq!(irq, 0x1337);
+
+    Ok(())
+}
+
+fn tlb_translate_exception_over_0x2000(
+    virtual_addr: u64,
+    _operation: MemoryOperation,
+    _memory_type: MemoryType,
+    processor: &mut TlbProcessor,
+) -> TlbTranslateResult {
+    info!("getting addr 0x{virtual_addr:X}");
+
+    // make sure reading registers works in here
+    let reg_value = processor
+        .cpu
+        .read_register::<u32>(Ppc32Register::R1)
+        .unwrap();
+    info!("got reg value {reg_value}");
+
+    if virtual_addr >= 0x1000 {
+        Err(TlbTranslateError::Exception(0x1337))
+    } else {
+        Ok(virtual_addr)
+    }
+}
+
+/// Test reading from a virtual address which causes an exception.
+///
+/// The pc is checked to make sure it did not increment.
+#[test]
+fn test_virtual_read_exception() -> Result<(), UnknownError> {
+    init_logging();
+
+    let mut cpu =
+        PcodeBackend::new_engine(Arch::Ppc32, Ppc32Variants::Ppc405, ArchEndian::BigEndian);
+    let physical_memory = PhysicalMemoryVariant::RegionStore;
+    let tlb = ClosureTlb::new(Box::new(tlb_translate_exception_over_0x2000));
+    let mut mmu = Mmu::new(Box::new(tlb), physical_memory, &mut cpu)?;
+    let mut ev = EventController::default();
+
+    let objdump = "
+       0:	3c 60 00 00 	lis     r3,0
+       4:	60 63 10 00 	ori     r3,r3,4096
+       8:	80 83 00 00 	lwz     r4,0(r3)
+   ";
+    let code_bytes = styx_util::parse_objdump(objdump)?;
+
+    let last_irq: Arc<Mutex<Option<ExceptionNumber>>> = Arc::new(Mutex::new(None));
+    {
+        let last_irq = last_irq.clone();
+        cpu.add_hook(StyxHook::interrupt(move |_cpu: CoreHandle, irqn| {
+            *last_irq.lock().unwrap() = Some(irqn);
+            Ok(())
+        }))?;
+    }
+
+    mmu.add_memory_region(MemoryRegion::new(0, 0x3000, MemoryPermissions::all())?)
+        .unwrap();
+
+    mmu.write_code(0x0, &code_bytes)?;
+    cpu.set_pc(0)?;
+
+    cpu.execute(&mut mmu, &mut ev, 3)?;
+
+    let irq = last_irq.lock().unwrap().unwrap();
+    assert_eq!(irq, 0x1337);
+
+    let pc = cpu.pc()?;
+    // exceptions require instruction to re-execute
+    assert_eq!(pc, 8);
+
+    Ok(())
+}
+
+/// Test writing to a virtual address that throws an exception.
+///
+/// The pc is checked to make sure it did not increment.
+#[test]
+fn test_virtual_write_exception() -> Result<(), UnknownError> {
+    init_logging();
+
+    let mut cpu =
+        PcodeBackend::new_engine(Arch::Ppc32, Ppc32Variants::Ppc405, ArchEndian::BigEndian);
+    let physical_memory = PhysicalMemoryVariant::RegionStore;
+    let tlb = ClosureTlb::new(Box::new(tlb_translate_exception_over_0x2000));
+    let mut mmu = Mmu::new(Box::new(tlb), physical_memory, &mut cpu)?;
+    let mut ev = EventController::default();
+
+    let objdump = "
+        0:	3c 60 00 00 	lis     r3,0
+        4:	60 63 10 00 	ori     r3,r3,4096
+        8:	3c 80 00 00 	lis     r4,0
+        c:	60 84 13 37 	ori     r4,r4,4919
+        10:	90 83 00 00 	stw     r4,0(r3)
+   ";
+    let code_bytes = styx_util::parse_objdump(objdump)?;
+
+    let last_irq: Arc<Mutex<Option<ExceptionNumber>>> = Arc::new(Mutex::new(None));
+    {
+        let last_irq = last_irq.clone();
+        cpu.add_hook(StyxHook::interrupt(move |_cpu: CoreHandle, irqn| {
+            *last_irq.lock().unwrap() = Some(irqn);
+            Ok(())
+        }))?;
+    }
+
+    mmu.add_memory_region(MemoryRegion::new(0, 0x3000, MemoryPermissions::all())?)
+        .unwrap();
+
+    mmu.write_code(0x0, &code_bytes)?;
+    cpu.set_pc(0)?;
+
+    cpu.execute(&mut mmu, &mut ev, 5)?;
+
+    let irq = last_irq.lock().unwrap().unwrap();
+    assert_eq!(irq, 0x1337);
+
+    let pc = cpu.pc()?;
+    // exceptions require instruction to re-execute
+    assert_eq!(pc, 0x10);
 
     Ok(())
 }

--- a/styx/core/styx-processor/src/memory/mmu.rs
+++ b/styx/core/styx-processor/src/memory/mmu.rs
@@ -22,14 +22,14 @@ pub enum MmuOpError {
     Other(#[from] UnknownError),
     #[error("encountered physical memory error")]
     PhysicalMemoryError(#[from] MemoryOperationError),
-    #[error("tlb exception")]
-    TlbException(Option<ExceptionNumber>),
+    #[error("TLB exception irq: {0:?}")]
+    TlbException(ExceptionNumber),
 }
 
 impl From<TlbTranslateError> for MmuOpError {
     fn from(value: TlbTranslateError) -> Self {
         match value {
-            TlbTranslateError::TlbException(exception) => Self::TlbException(exception),
+            TlbTranslateError::Exception(exception) => Self::TlbException(exception),
             TlbTranslateError::Other(error) => Self::Other(error),
         }
     }

--- a/styx/processors/ppc/styx-ppc4xx-processor/src/tlb/mod.rs
+++ b/styx/processors/ppc/styx-ppc4xx-processor/src/tlb/mod.rs
@@ -304,16 +304,12 @@ impl TlbImpl for Ppc405Tlb {
                         if (record.pid != 0 && record.pid != current_pid)
                             || (access_type == MemoryOperation::Write && !record.write_enabled)
                         {
-                            Err(TlbTranslateError::TlbException(Some(
-                                Event::DataStorage.into(),
-                            )))
+                            Err(TlbTranslateError::Exception(Event::DataStorage.into()))
                         } else {
                             Ok(record.translate_v_addr(v_address))
                         }
                     } else {
-                        Err(TlbTranslateError::TlbException(Some(
-                            Event::DataTLBError.into(),
-                        )))
+                        Err(TlbTranslateError::Exception(Event::DataTLBError.into()))
                     }
                 } else {
                     Ok(v_address)
@@ -326,14 +322,14 @@ impl TlbImpl for Ppc405Tlb {
                         if (record.pid == 0 || record.pid == current_pid) && record.exec_enabled {
                             Ok(record.translate_v_addr(v_address))
                         } else {
-                            Err(TlbTranslateError::TlbException(Some(
+                            Err(TlbTranslateError::Exception(
                                 Event::InstructionStorage.into(),
-                            )))
+                            ))
                         }
                     } else {
-                        Err(TlbTranslateError::TlbException(Some(
+                        Err(TlbTranslateError::Exception(
                             Event::InstructionTLBError.into(),
-                        )))
+                        ))
                     }
                 } else {
                     Ok(v_address)


### PR DESCRIPTION
This allows for the TLB implementation to access CPU state (registers) for its translation and permissions checks.

This also adds `virt_read()/virt_write()` methods to the MMU. The default read/write methods operate on physical memory while these operate on virtual memory.

This also hooks in the read/write virtual memory to the PcodeBackend so that it will properly translate addresses during execution. Tests for this are in `virtual_addressing.rs`.

Pcode backend behavior is described in the doc comment for the `PcodeBackend` but it is copied here as well:
```
// Currently, the only exceptions implemented are the ones thrown by the
/// [TLB](styx_processor::memory::TlbImpl) (see
/// [TlbTranslateError::Exception](styx_processor::memory::TlbTranslateError::Exception)). When the
/// TLB indicates an exception, the rest of the pcodes in the instruction are not run and an
/// interrupt hook is triggered with the exception number give by the TLB. The Pc is not
/// incremented. It is expected that the interrupt hook handles the TLB exception as required by the
/// processor manual. With no intervention, the instruction will be run again, possibly throwing the
/// same TLB exception.
```