### PR TITLE
misc: use [target.<cfg>] for rustflags to allow unification

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,14 @@
-[build]
+# apply to all invocations
+# uses [target.<cfg>] to allow unification of rustflag options in other cargo configs
+# see https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags
+# TODO change to cfg(true) after upgrade to rust 1.88
+[target.'cfg(all())']
 rustflags = [
   "--cfg",
   "tokio_unstable", # we always build with tokio_unstable so tracing plugins can be used w/o pain
 ]
+# keep flags the same, avoid rebuilds
+rustdocflags = ["--cfg", "tokio_unstable"]
 
 [alias]
 xtask = "run --package xtask --"

--- a/.envrc
+++ b/.envrc
@@ -18,13 +18,6 @@ export CI_REGISTRY_IMAGE=${CI_REGISTRY_IMAGE:-${CI_REGISTRY}/${CI_PROJECT_PATH}}
 export CI_REPOSITORY_URL=${CI_REPOSITORY_URL:-https://github.com/styx-emulator/styx-emulator}
 export STYX_ROOT="$CI_PROJECT_DIR"
 
-## FOLLOWS compile cfgs from /.cargo/config.toml
-# this significantly reduces the rebuilds due to rust-analyzer
-# going ham
-export RUSTFLAGS="${RUSTFLAGS} --cfg tokio_unstable"
-export RUSTDOCFLAGS="${RUSTDOCFLAGS} --cfg tokio_unstable"
-## END FOLLOWS
-
 # Prepend RUST built binaries
 RUST_RUN_BUILD_CONFIG=${RUST_RUN_BUILD_CONFIG:-debug}
 export DEPLOY_BINS_DIR=${DEPLOY_BINS_DIR:-"${CI_PROJECT_DIR}"/target/"${RUST_RUN_BUILD_CONFIG}"}


### PR DESCRIPTION
According to the [rust documentation on
build.rustflags](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags),  if you specify the `RUSTFLAGS` env variable or `build.rustflags` in a .cargo/config.toml then those flags will be used exclusively. This is not good because it disallows user specific rustflags given from ~/.cargo/config.toml.

This commit changes these to use the [target.<cfg>] table which will combine all applicible cfg rustflags options.

This also removes the .envrc override of the RUSTFLAGS environment variable.