### PR TITLE
Remove target tracebus event

### DIFF
--- a/incubation/trace-tools/src/emu_observer.rs
+++ b/incubation/trace-tools/src/emu_observer.rs
@@ -689,18 +689,6 @@ impl EmulationObserver {
                 debug!("ignore {}", e.text());
                 vec![]
             }
-            TraceableItem::Stm32Event(e) => {
-                debug!("ignore {}", e.text());
-                vec![]
-            }
-            TraceableItem::Kinetis21Event(e) => {
-                debug!("ignore {}", e.text());
-                vec![]
-            }
-            TraceableItem::PowerQuiccEvent(e) => {
-                debug!("ignore {}", e.text());
-                vec![]
-            }
         }
     }
 }

--- a/styx/core/styx-tracebus/src/lib.rs
+++ b/styx/core/styx-tracebus/src/lib.rs
@@ -316,9 +316,6 @@ bitflags! {
         const REG_WRITE =   0x0040;
         const BRANCH =      0x0080;
         const INTERRUPT =   0x0100;
-        const STM32 =       0x0200;
-        const KINETIS21  =  0x0400;
-        const POWERQUICC =  0x0800;
         const BLOCK =       0x1000;
         // const TET_RESERVED_2 =  0x2000;
         // const TET_RESERVED_3 =  0x4000;
@@ -511,13 +508,10 @@ pub enum TraceableItem {
     InsnExecEvent(TraceEventType::INST_EXEC),
     InsnFetchEvent(TraceEventType::INST_FETCH),
     InterruptEvent(TraceEventType::INTERRUPT),
-    Kinetis21Event(TraceEventType::KINETIS21),
     MemReadEvent(TraceEventType::MEM_READ),
     MemWriteEvent(TraceEventType::MEM_WRT),
-    PowerQuiccEvent(TraceEventType::POWERQUICC),
     RegReadEvent(TraceEventType::REG_READ),
     RegWriteEvent(TraceEventType::REG_WRITE),
-    Stm32Event(TraceEventType::STM32),
 }
 
 /// Event representing entering a basic block.
@@ -636,33 +630,6 @@ pub struct InterruptEvent {
     pub interrupt_num: i32,
     pub old_pc: u32,
     pub new_pc: u32,
-}
-
-/// Stm32 ...
-#[styx_event(etype=TraceEventType::STM32)]
-pub struct Stm32Event {
-    pub reserved_u16: u16,
-    pub reserved_1: u32,
-    pub reserved_2: u32,
-    pub reserved_3: u32,
-}
-
-/// Kinetis21 ...
-#[styx_event(etype=TraceEventType::KINETIS21)]
-pub struct Kinetis21Event {
-    pub reserved_u16: u16,
-    pub reserved_1: u32,
-    pub reserved_2: u32,
-    pub reserved_3: u32,
-}
-
-/// Stm32 ...
-#[styx_event(etype=TraceEventType::POWERQUICC)]
-pub struct PowerQuiccEvent {
-    pub reserved_u16: u16,
-    pub reserved_1: u32,
-    pub reserved_2: u32,
-    pub reserved_3: u32,
 }
 
 #[cfg(test)]

--- a/styx/processors/arm/styx-kinetis21-processor/src/gpio/port.rs
+++ b/styx/processors/arm/styx-kinetis21-processor/src/gpio/port.rs
@@ -8,18 +8,15 @@ use super::{
 };
 use std::{collections::BTreeMap, ops::RangeInclusive};
 use styx_core::prelude::*;
-use styx_core::tracebus::{strace, Kinetis21Event, TraceProvider};
 use tracing::{trace, warn};
 
 /// Helper function for tracing GPIO register writes.
 fn trace_reg_write(gpio_name: &str, reg_name: &str, regval: u32) {
-    strace!(Kinetis21Event::new());
     trace!("GPIO_{} write to {} = {:#08x}", gpio_name, reg_name, regval);
 }
 
 /// Helper function for tracing GPIO register reads.
 fn trace_reg_read(gpio_name: &str, reg: GpioRegister) {
-    strace!(Kinetis21Event::new());
     trace!("GPIO_{} read from {}", gpio_name, reg);
 }
 
@@ -282,7 +279,6 @@ impl GPIOPort {
             trace_reg_read(self.name, GpioRegister::PDDR);
         } else if self.addr_range.contains(&address) {
             // All other registers (PSOR, PCOR and PTOR) return zero when read.
-            strace!(Kinetis21Event::new());
             trace!(
                 "GPIO_{} read from PSOR, PCOR or PTOR register ({:#08x}) - always read as zero.",
                 self.name,

--- a/styx/processors/arm/styx-stm32f107-processor/src/example_gpio.rs
+++ b/styx/processors/arm/styx-stm32f107-processor/src/example_gpio.rs
@@ -556,7 +556,7 @@ pub mod port {
     use styx_core::{
         hooks::StyxHook,
         prelude::*,
-        tracebus::{strace, MemWriteEvent, Stm32Event, TraceEventType},
+        tracebus::{strace, MemWriteEvent, TraceEventType},
     };
     use tracing::{debug, info, warn};
 
@@ -674,10 +674,8 @@ pub mod port {
                 let (br, bs) = pin.bsrr(regval);
                 if bs {
                     info!("    => BSSR: Sets port {} pin {}", self.name, pin.pno);
-                    strace!(Stm32Event::new());
                 } else if br {
                     info!("    => BSSR: Resets port {} pin {}", self.name, pin.pno);
-                    strace!(Stm32Event::new());
                 }
             }
         }

--- a/styx/processors/arm/styx-stm32f107-processor/tests/factory_to_styx_trace.rs
+++ b/styx/processors/arm/styx-stm32f107-processor/tests/factory_to_styx_trace.rs
@@ -16,13 +16,13 @@ use styx_stm32f107_processor::Stm32f107Builder;
 use tap::Conv;
 
 /// expect at least this many events
-const MIN_EVENTS: usize = 1;
+const MIN_EVENTS: usize = 1000;
 /// expect no more than this main events
-const MAX_EVENTS: usize = 1;
+const MAX_EVENTS: usize = usize::MAX;
 /// How long to run the test before stoping the `Processor`
 const TEST_DURATION: Duration = Duration::from_millis(1000);
 /// The test event type (mask) we are looking for
-const EVENT_MASK: TraceEventType = TraceEventType::STM32;
+const EVENT_MASK: TraceEventType = TraceEventType::MEM_WRT;
 
 /// test blink_flash with `EmulationArgs`. All the assertions are
 /// performed in [run_blink_flash](fn@common::run_blink_flash)


### PR DESCRIPTION
this removes some largely unused trace events that probably shouldnt have been here in the first place. as a part of the upcoming trace spec RFC im putting together this intended behavior that never materialized will finally show up! and not in a way that takes up a whole section of the enum.

- remove `Stm32Event`
- remove `PowerQUICCEvent`
- remove `KinetisEvent`