### PR TITLE
misc: add cache-bin: false to rust-cache

### DIFF
--- a/.github/workflows/c-bindings-ci.yml
+++ b/.github/workflows/c-bindings-ci.yml
@@ -49,6 +49,8 @@ jobs:
         components: ''
 
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-bin: "false"
 
     - name: Enter Virtual Environment
       shell: bash

--- a/.github/workflows/cargo-ci.yml
+++ b/.github/workflows/cargo-ci.yml
@@ -25,6 +25,8 @@ jobs:
       uses: actions/checkout@v4
 
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-bin: "false"
 
     - name: run doc tests
       shell: bash
@@ -45,6 +47,8 @@ jobs:
       uses: actions/checkout@v4
 
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-bin: "false"
 
     - name: cargo test bindings
       shell: bash
@@ -65,6 +69,8 @@ jobs:
       uses: actions/checkout@v4
 
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-bin: "false"
 
     - name: Test
       shell: bash

--- a/.github/workflows/cargo-udeps.yml
+++ b/.github/workflows/cargo-udeps.yml
@@ -37,6 +37,8 @@ jobs:
         components: ''
 
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-bin: "false"
 
     - name: Run cargo-udeps
       shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,8 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-bin: "false"
 
     - name: Run base lints
       shell: bash
@@ -37,6 +39,8 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-bin: "false"
 
     - name: taplo toml format check
       shell: bash
@@ -51,6 +55,8 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-bin: "false"
 
     - name: rustfmt
       shell: bash
@@ -65,6 +71,8 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-bin: "false"
 
     - name: cargo clippy
       shell: bash
@@ -85,6 +93,8 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-bin: "false"
 
     - name: Lint RustDocs
       shell: bash
@@ -104,6 +114,8 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-bin: "false"
 
     - name: Lint workspace-hack
       shell: bash
@@ -123,6 +135,8 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-bin: "false"
 
     - name: License check
       shell: bash

--- a/.github/workflows/python-bindings-ci.yml
+++ b/.github/workflows/python-bindings-ci.yml
@@ -52,6 +52,8 @@ jobs:
         components: ''
 
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-bin: "false"
 
     - name: Enter Virtual Environment
       shell: bash

--- a/.github/workflows/python-bindings-examples.yml
+++ b/.github/workflows/python-bindings-examples.yml
@@ -52,6 +52,8 @@ jobs:
           components: ""
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: "false"
 
       - name: Enter Virtual Environment
         run: |


### PR DESCRIPTION
This prevents Swatinem/rust-cache@v2 from deleting .cargo/bin.

Source:
https://github.com/Swatinem/rust-cache/tree/master?tab=readme-ov-file#known-issues