### PR TITLE
docs: fix truncation of quickstart RawProcessor example & typo

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -12,12 +12,12 @@ After completing the :ref:`installing` of ``Styx`` as a dependency of your crate
 
 
 .. literalinclude:: ../../examples/raw-processor/src/main.rs
-    :lines: 26-
+    :lines: 2-
     :linenos:
     :language: rust
 
-Note that line 17,18,19 are optional plugins, where the ``ProcessorTracingPlugin``
-provides easy avenues to get output from processors, and the ``*MemoryFautlPlugins``
+Note that line 20,21,22 are optional plugins, where the ``ProcessorTracingPlugin``
+provides easy avenues to get output from processors, and the ``*MemoryFaultPlugins``
 provide an easy ability to stop when a memory releated error occurs in the
 ``TargetProgram``.
 
@@ -75,4 +75,4 @@ And a similar use via the python API:
 .. literalinclude:: ../../styx/bindings/styx-py-api/examples/simple-stm32f107/main.py
     :language: python
     :linenos:
-    :lines: 27-
+    :lines: 26-


### PR DESCRIPTION
1. noticed some small typos in Sphinx docs quickstart page, when built currently the RawProcessor usage example is truncated due to the value of `26-` as the Sphix :lines: directive; only displaying 3 LoC which do not illustrate usage of the RawProcessor builder. this should be `2-` to align with sample code available in the public repo... perhaps leftover from pre-FOSS codebase?
https://github.com/styx-emulator/styx-emulator/blob/f276c31a57876e7cc4408f52a44047aabb83e29a/docs/source/quickstart.rst?plain=1#L14-L17 https://github.com/styx-emulator/styx-emulator/blob/f276c31a57876e7cc4408f52a44047aabb83e29a/examples/raw-processor/src/main.rs#L2-L32

2. similarly small typo fixed of ``*MemoryFautlPlugins`` -> ``*MemoryFaultPlugins``
https://github.com/styx-emulator/styx-emulator/blob/f276c31a57876e7cc4408f52a44047aabb83e29a/docs/source/quickstart.rst?plain=1#L20

3. python bindings example usage also omits initialisation of the ProcessorBuilder, :lines: directive changed from `27-` -> `26-`
https://github.com/styx-emulator/styx-emulator/blob/f276c31a57876e7cc4408f52a44047aabb83e29a/docs/source/quickstart.rst?plain=1#L75-L78 https://github.com/styx-emulator/styx-emulator/blob/f276c31a57876e7cc4408f52a44047aabb83e29a/styx/bindings/styx-py-api/examples/simple-stm32f107/main.py#L26-L36