### PR TITLE
fix: rust API docs redirect

### DIFF
--- a/data/misc/redirect.html
+++ b/data/misc/redirect.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; URL=styx/index.html"/>
+<meta http-equiv="refresh" content="0; URL=styx_emulator/index.html"/>


### PR DESCRIPTION
After running `just rust-docs`, the instructions indicate to open `./target/doc/index.html`, but when you do so, the meta refresh `<meta http-equiv="refresh" content="0; URL=styx/index.html"/>` instructs the browser to open `./target/doc/styx/index.html`, which doesn't exist. I believe the right file is `./target/doc/styx_emulator/index.html`.