### PR TITLE
chore: add error contexts to loader operations

### DIFF
--- a/styx/core/styx-loader/src/loaders/parameterized.rs
+++ b/styx/core/styx-loader/src/loaders/parameterized.rs
@@ -211,7 +211,8 @@ impl Loader for ParameterizedLoader {
                     // FIXME: We will ultimately need to support rebasing an ELF. Until then, we
                     // cannot do anything with the base address.
                     let path = Path::new(&elf_record.file);
-                    let data = fs::read(path)?;
+                    let data = fs::read(path)
+                        .with_context(|| format!("Failed to read ELF file {}", path.display()))?;
                     let mut elf_desc: MemoryLoaderDesc =
                         load_elf(&ElfLoaderConfig::default(), &data, HashMap::new()).unwrap();
 
@@ -223,7 +224,8 @@ impl Loader for ParameterizedLoader {
                 LoadRecordType::FileRaw(raw_record) => {
                     // Load the raw file into memory using the raw file loader.
                     let path = Path::new(&raw_record.file);
-                    let data = fs::read(path)?;
+                    let data = fs::read(path)
+                        .with_context(|| format!("Failed to read raw file {}", path.display()))?;
                     match raw_record.perms {
                         Some(perms) => {
                             let mut raw_desc: MemoryLoaderDesc =

--- a/styx/core/styx-processor/src/processor/builder.rs
+++ b/styx/core/styx-processor/src/processor/builder.rs
@@ -36,9 +36,11 @@ enum TargetProgramSource<'a> {
 }
 
 impl<'a> TargetProgramSource<'a> {
-    pub fn bytes(self) -> Result<Cow<'a, [u8]>, std::io::Error> {
+    pub fn bytes(self) -> Result<Cow<'a, [u8]>, styx_errors::UnknownError> {
         match self {
-            TargetProgramSource::File(file_name) => std::fs::read(file_name).map(Cow::Owned),
+            TargetProgramSource::File(ref file_name) => std::fs::read(file_name)
+                .map(Cow::Owned)
+                .with_context(|| format!("Failed to read target program from file {file_name}")),
             TargetProgramSource::Memory(cow) => Ok(cow),
         }
     }
@@ -356,7 +358,7 @@ fn autobots_load_up(
     // loader hints?
     let mut memory_desc = loader
         .load_bytes(source_bytes, hints)
-        .context("failed to let loader load bytes")?;
+        .context("Loader failed to load bytes")?;
 
     // todo these should be more compatible
     let regions = memory_desc.take_memory_regions();


### PR DESCRIPTION
Add some `anyhow::Context`s to some loader operations