### PR TITLE
Llsc compare exchange

### DIFF
--- a/styx/core/styx-processor/src/memory/atomic_word.rs
+++ b/styx/core/styx-processor/src/memory/atomic_word.rs
@@ -49,6 +49,21 @@ pub(in crate::memory) struct AlignmentError {
     size: usize,
 }
 
+#[derive(Error, Debug)]
+#[error("Size of old and new slices must be the same in compare exchange (current: {current_size} vs new: {new_size})")]
+pub struct CompareExchangeSizeMismatch {
+    current_size: usize,
+    new_size: usize,
+}
+
+#[derive(Error, Debug)]
+pub(in crate::memory) enum CompareExchangeError {
+    #[error(transparent)]
+    Alignment(#[from] AlignmentError),
+    #[error(transparent)]
+    SizeMismatch(#[from] CompareExchangeSizeMismatch),
+}
+
 impl AtomicWord {
     pub(in crate::memory) const WORD_SIZE_BYTES: usize = std::mem::size_of::<Self>();
 
@@ -132,15 +147,64 @@ impl AtomicWord {
     }
 
     /// Updates the value in the word if `current` is the current bytes in the word, akin to [`AtomicU64::compare_exchange()`].
-    #[allow(unused)]
-    pub(in crate::memory) fn compare_and_swap(
+    ///
+    /// This is *technically* a **weak** compare and swap operation.
+    /// To approximate `< WORD_SIZE` operations, we first load the
+    /// current value of the word, then modify the operations bytes (starting at `idx`).
+    /// Then we use the native [`AtomicU64::compare_exchange()`] to do the final compare and swap.
+    /// If a writer changes the values in the word that are not a part of the operation (i.e. not in `word[idx..idx+current.len()]`),
+    /// then the operation will fail, despite the bytes checked by `current` being the same.
+    ///
+    /// In reality, this window is very small, and the compare and swap operation will not spuriously succeed.
+    ///
+    /// Sequence of operations:
+    ///
+    /// ```ignore
+    /// 1. loaded = Load word
+    /// 2. current_u64 = (loaded & mask) | current <-- A write here could cause a fail even though the value at idx == current
+    /// 3. new_u64 = (loaded & mask) | new <-- Same thing here
+    /// 4. word.compare_exchange(current_u64, new_u64)
+    /// ```
+    pub(in crate::memory) fn compare_exchange(
         &self,
         idx: usize,
         current: &[u8],
         new: &[u8],
-    ) -> Result<CompareAndSwapResult, AlignmentError> {
-        // This will use AtomicU64 compare and swap with read_from_word and write_to_word
-        todo!()
+    ) -> Result<CompareExchangeResult, CompareExchangeError> {
+        Self::check(idx, current.len())?;
+        Self::check(idx, new.len())?;
+        if current.len() != new.len() {
+            return Err(CompareExchangeSizeMismatch {
+                current_size: current.len(),
+                new_size: new.len(),
+            }
+            .into());
+        }
+        // now we know idx and current/new are appropriately sized
+        let op_size = current.len();
+
+        // To do this operation will will load the value from self,
+        // mask and apply the bytes from `current`, then compare_exchange.
+
+        let load_value = self.0.load(Ordering::Relaxed).to_ne_bytes();
+        let mut current_load_value = load_value;
+        current_load_value[idx..idx + op_size].copy_from_slice(current);
+        let current_value = NonAtomicWord::from_ne_bytes(current_load_value);
+        let mut new_load_value = load_value;
+        new_load_value[idx..idx + op_size].copy_from_slice(new);
+        let new_value = NonAtomicWord::from_ne_bytes(new_load_value);
+
+        let result = self.0.compare_exchange(
+            current_value,
+            new_value,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        );
+
+        match result {
+            Ok(_) => Ok(CompareExchangeResult::Success),
+            Err(_) => Ok(CompareExchangeResult::Failure),
+        }
     }
 
     /// Convert to in-memory representation.
@@ -156,13 +220,18 @@ impl AtomicWord {
     }
 }
 
-pub enum CompareAndSwapResult {
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum CompareExchangeResult {
     /// The swap succeeded.
-    #[allow(unused)]
     Success,
     /// The swap was not performed.
-    #[allow(unused)]
     Failure,
+}
+
+impl CompareExchangeResult {
+    pub fn success(self) -> bool {
+        CompareExchangeResult::Success == self
+    }
 }
 
 /// Copy a idx and size from an Atomic.
@@ -308,6 +377,52 @@ mod tests {
 
         for i in 0..user_bytes.len() {
             assert_eq!(raw_bytes[idx + i], user_bytes[i])
+        }
+    }
+
+    /// Tests compare and swap
+    ///
+    /// - First arg: idx and bytes of initial value of word.
+    ///   This is also the "old"/current value in compare and swap operation
+    /// - Second arg: Optional idx and bytes of write, before compare and swap
+    /// - Third arg: bytes of new value to write if compare and swap operation succeeds.
+    ///   same idx as first arg, must be same size as first arg
+    // No writes between Load and Compare and swap, should always succeed
+    #[test_case((0, &[0x12, 0x34]), None,  &[0x13, 0x37], CompareExchangeResult::Success)]
+    #[test_case((4, &[0x12, 0x34]), None, &[0x13, 0x37], CompareExchangeResult::Success)]
+    #[test_case((0, &[0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0]), None, &[0x13, 0x37, 0xDE, 0xAD, 0xBE, 0xEF, 0xBA, 0xBE], CompareExchangeResult::Success)]
+    #[test_case((6, &[0x12, 0x34]), None, &[0x13, 0x37], CompareExchangeResult::Success)]
+    #[test_case((4, &[0x12, 0x34, 0x56, 0x78]), None, &[0x13, 0x37, 0x13, 0x37], CompareExchangeResult::Success)]
+    // Overwrite, now the compare and swap fails
+    #[test_case((4, &[0x12, 0x34]), Some((4, &[0x99, 0x99])), &[0x13, 0x37], CompareExchangeResult::Failure)]
+    #[test_case((4, &[0x12, 0x34]), Some((2, &[0x99, 0x99, 0x99])), &[0x13, 0x37], CompareExchangeResult::Failure)]
+    #[test_case((4, &[0x12, 0x34]), Some((4, &[0x12, 0x34])), &[0x13, 0x37], CompareExchangeResult::Success)]
+    // The operations do not overlap
+    #[test_case((4, &[0x12, 0x34]), Some((0, &[0x99, 0x99])), &[0x13, 0x37], CompareExchangeResult::Success)]
+    // The operations do not overlap
+    #[test_case((2, &[0x12, 0x34]), Some((0, &[0x99, 0x99])), &[0x13, 0x37], CompareExchangeResult::Success)]
+    fn test_compare_exchange(
+        old_bytes: (usize, &[u8]),
+        write_bytes: Option<(usize, &[u8])>,
+        final_write: &[u8],
+        expected: CompareExchangeResult,
+    ) {
+        let word = AtomicWord::default();
+        word.write(old_bytes.0, old_bytes.1).unwrap();
+
+        if let Some((idx, bytes)) = write_bytes {
+            word.write(idx, bytes).unwrap();
+        }
+
+        let result = word
+            .compare_exchange(old_bytes.0, old_bytes.1, final_write)
+            .unwrap();
+
+        assert_eq!(result, expected);
+        if result.success() {
+            let mut buffer = vec![0u8; final_write.len()];
+            word.read(old_bytes.0, &mut buffer).unwrap();
+            assert_eq!(&buffer, final_write)
         }
     }
 }

--- a/styx/core/styx-processor/src/memory/llsc.rs
+++ b/styx/core/styx-processor/src/memory/llsc.rs
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: BSD-2-Clause
+//! Load-Linked/Store-Conditional methods for Mmu.
+use tap::Conv;
+use thiserror::Error;
+
+use crate::cpu::CpuBackend;
+
+use super::{
+    atomic_word::AtomicWord, physical::AtomicMemoryOperationError, CompareExchangeError,
+    MemoryOperation, MemoryType, Mmu, TlbTranslateError,
+};
+
+/// Returned from a Load Linked call to enable a Store Conditional.
+///
+/// Refer to the [module documentation](crate::memory#load-linkstore-conditional)
+/// for detailed information and gotchas.
+pub struct Load {
+    /// Address of access.
+    ///
+    /// Used to sanity check that the SC and LL match.
+    address: u64,
+    /// Value of `*address`, spans `size` bytes.
+    value: [u8; AtomicWord::WORD_SIZE_BYTES],
+    /// Indicates size of `value`.
+    size: usize,
+}
+
+impl Load {
+    /// Loaded data from the Load Linked operation.
+    pub fn data(&self) -> &[u8] {
+        &self.value[..self.size]
+    }
+
+    /// Address of the Load Linked operation.
+    pub fn address(&self) -> u64 {
+        self.address
+    }
+}
+
+impl Mmu {
+    /// Loads and reserves `*paddr` in data memory in memory for future [`Mmu::store_conditional_data()`].
+    ///
+    /// Use the `code`/`data` variant that is most appropriate.
+    /// For Von Neumann architectures, `data` vs `code` has no effect.
+    ///
+    /// Refer to the [module documentation](crate::memory#load-linkstore-conditional)
+    /// for detailed information and gotchas.
+    pub fn load_linked_data(
+        &self,
+        paddr: u64,
+        size: usize,
+    ) -> Result<Load, AtomicMemoryOperationError> {
+        let mut load = check_load(paddr, size)?;
+        self.read_data(paddr, &mut load.value[..size])?;
+        Ok(load)
+    }
+
+    /// Loads and reserves `*paddr` in code memory in memory for future [`Mmu::store_conditional_code()`].
+    ///
+    /// Use the `code`/`data` variant that is most appropriate.
+    /// For Von Neumann architectures, `data` vs `code` has no effect.
+    ///
+    /// Refer to the [module documentation](crate::memory#load-linkstore-conditional)
+    /// for detailed information and gotchas.
+    pub fn load_linked_code(
+        &self,
+        paddr: u64,
+        size: usize,
+    ) -> Result<Load, AtomicMemoryOperationError> {
+        let mut load = check_load(paddr, size)?;
+        self.read_code(paddr, &mut load.value[..size])?;
+        Ok(load)
+    }
+
+    /// Loads and reserves `*vaddr` in data memory in memory for future [`Mmu::virt_store_conditional_data()`].
+    ///
+    /// Use the `code`/`data` variant that is most appropriate.
+    /// For Von Neumann architectures, `data` vs `code` has no effect.
+    ///
+    /// Refer to the [module documentation](crate::memory#load-linkstore-conditional)
+    /// for detailed information and gotchas.
+    pub fn virt_load_linked_data(
+        &mut self,
+        vaddr: u64,
+        size: usize,
+        cpu: &mut dyn CpuBackend,
+    ) -> Result<Load, AtomicMmuOpError> {
+        let phys_addr = self.translate_va(vaddr, MemoryOperation::Read, MemoryType::Data, cpu)?;
+        let mut load = check_load(phys_addr, size)?;
+        self.read_data(vaddr, &mut load.value[..size])
+            .map_err(|e| e.conv::<AtomicMemoryOperationError>())?;
+        Ok(load)
+    }
+
+    /// Loads and reserves `*vaddr` in code memory in memory for future [`Mmu::virt_store_conditional_code()`].
+    ///
+    /// Use the `code`/`data` variant that is most appropriate.
+    /// For Von Neumann architectures, `data` vs `code` has no effect.
+    ///
+    /// Refer to the [module documentation](crate::memory#load-linkstore-conditional)
+    /// for detailed information and gotchas.
+    pub fn virt_load_linked_code(
+        &mut self,
+        vaddr: u64,
+        size: usize,
+        cpu: &mut dyn CpuBackend,
+    ) -> Result<Load, AtomicMmuOpError> {
+        let phys_addr = self.translate_va(vaddr, MemoryOperation::Read, MemoryType::Code, cpu)?;
+        let mut load = check_load(phys_addr, size)?;
+        self.read_code(vaddr, &mut load.value[..size])
+            .map_err(|e| e.conv::<AtomicMemoryOperationError>())?;
+        Ok(load)
+    }
+
+    /// Conditionally store `*paddr` that was reserved from a previous [`Mmu::load_linked_data()`].
+    ///
+    /// [`StoreConditionalResult`] is successful if the current value of `*paddr` is the same as
+    /// captured at the time of the `load`.
+    /// Note: this is different behavior from traditional LL/SC that would fail if the value is the same
+    /// but the memory what written to.
+    ///
+    /// Refer to the [module documentation](crate::memory#load-linkstore-conditional)
+    /// for detailed information and gotchas.
+    pub fn store_conditional_data(
+        &self,
+        paddr: u64,
+        load: Load,
+        store: &[u8],
+    ) -> Result<StoreConditionalResult, StoreConditionalError> {
+        if paddr != load.address {
+            return Err(StoreConditionalError::MismatchAddress(paddr, load.address));
+        }
+
+        Ok(StoreConditionalResult::from_success(
+            self.compare_exchange_data(paddr, load.data(), store)?
+                .success(),
+        ))
+    }
+
+    /// Conditionally store `*paddr` that was reserved from a previous [`Mmu::load_linked_code()`].
+    ///
+    /// [`StoreConditionalResult`] is successful if the current value of `*paddr` is the same as
+    /// captured at the time of the `load`.
+    /// Note: this is different behavior from traditional LL/SC that would fail if the value is the same
+    /// but the memory what written to.
+    ///
+    /// Refer to the [module documentation](crate::memory#load-linkstore-conditional)
+    /// for detailed information and gotchas.
+    pub fn store_conditional_code(
+        &self,
+        paddr: u64,
+        load: Load,
+        store: &[u8],
+    ) -> Result<StoreConditionalResult, StoreConditionalError> {
+        if paddr != load.address {
+            return Err(StoreConditionalError::MismatchAddress(paddr, load.address));
+        }
+
+        Ok(StoreConditionalResult::from_success(
+            self.compare_exchange_code(paddr, load.data(), store)?
+                .success(),
+        ))
+    }
+
+    /// Conditionally store `*vaddr` that was reserved from a previous [`Mmu::virt_load_linked_data()`].
+    ///
+    /// [`StoreConditionalResult`] is successful if the current value of `*vaddr` is the same as
+    /// captured at the time of the `load`.
+    /// Note: this is different behavior from traditional LL/SC that would fail if the value is the same
+    /// but the memory what written to.
+    ///
+    /// Refer to the [module documentation](crate::memory#load-linkstore-conditional)
+    /// for detailed information and gotchas.
+    pub fn virt_store_conditional_data(
+        &mut self,
+        vaddr: u64,
+        load: Load,
+        store: &[u8],
+        cpu: &mut dyn CpuBackend,
+    ) -> Result<StoreConditionalResult, VirtStoreConditionalError> {
+        if vaddr != load.address {
+            return Err(StoreConditionalError::MismatchAddress(vaddr, load.address).into());
+        }
+        let paddr = self.translate_va(vaddr, MemoryOperation::Read, MemoryType::Data, cpu)?;
+        Ok(StoreConditionalResult::from_success(
+            self.compare_exchange_data(paddr, load.data(), store)
+                .map_err(|e| e.conv::<StoreConditionalError>())?
+                .success(),
+        ))
+    }
+
+    /// Conditionally store `*vaddr` that was reserved from a previous [`Mmu::virt_load_linked_code()`].
+    ///
+    /// [`StoreConditionalResult`] is successful if the current value of `*vaddr` is the same as
+    /// captured at the time of the `load`.
+    /// Note: this is different behavior from traditional LL/SC that would fail if the value is the same
+    /// but the memory what written to.
+    ///
+    /// Refer to the [module documentation](crate::memory#load-linkstore-conditional)
+    /// for detailed information and gotchas.
+    pub fn virt_store_conditional_code(
+        &mut self,
+        vaddr: u64,
+        load: Load,
+        store: &[u8],
+        cpu: &mut dyn CpuBackend,
+    ) -> Result<StoreConditionalResult, VirtStoreConditionalError> {
+        if vaddr != load.address {
+            return Err(StoreConditionalError::MismatchAddress(vaddr, load.address).into());
+        }
+        let paddr = self.translate_va(vaddr, MemoryOperation::Read, MemoryType::Code, cpu)?;
+        Ok(StoreConditionalResult::from_success(
+            self.compare_exchange_code(paddr, load.data(), store)
+                .map_err(|e| e.conv::<StoreConditionalError>())?
+                .success(),
+        ))
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum StoreConditionalError {
+    #[error("mismatched address")]
+    MismatchAddress(u64, u64),
+    #[error(transparent)]
+    AtomicOperation(#[from] CompareExchangeError),
+}
+
+/// Success of [`Mmu::store_conditional_data()`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoreConditionalResult {
+    Success,
+    Failure,
+}
+impl StoreConditionalResult {
+    pub fn from_success(success: bool) -> Self {
+        if success {
+            Self::Success
+        } else {
+            Self::Failure
+        }
+    }
+
+    pub fn success(self) -> bool {
+        match self {
+            StoreConditionalResult::Success => true,
+            StoreConditionalResult::Failure => false,
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum AtomicMmuOpError {
+    #[error("encountered physical memory error")]
+    PhysicalMemoryError(#[from] AtomicMemoryOperationError),
+    #[error(transparent)]
+    TlbTranslateError(#[from] TlbTranslateError),
+}
+
+#[derive(Error, Debug)]
+pub enum VirtStoreConditionalError {
+    #[error(transparent)]
+    TlbTranslateError(#[from] TlbTranslateError),
+    #[error(transparent)]
+    StoreConditionalError(#[from] StoreConditionalError),
+}
+
+/// Helper, verifies size of atomic load fits in [`AtomicWord`].
+fn check_load(address: u64, size: usize) -> Result<Load, AtomicMemoryOperationError> {
+    // this check is to avoid a panic when we index into `load.value`.
+    if size > AtomicWord::WORD_SIZE_BYTES {
+        return Err(AtomicMemoryOperationError::TooLarge {
+            address,
+            bytes: size,
+            max_size: AtomicWord::WORD_SIZE_BYTES,
+        });
+    }
+
+    Ok(Load {
+        address,
+        size,
+        value: [0u8; AtomicWord::WORD_SIZE_BYTES],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::memory::helpers::{ReadExt, WriteExt};
+
+    use super::*;
+
+    #[test]
+    fn test_ll_sc() {
+        const ADDRESS: u64 = 0x1000;
+        let mut mmu = Mmu::default();
+        mmu.data().write(ADDRESS).bytes(&[0x12, 0x34]).unwrap();
+
+        let ll = mmu.load_linked_data(ADDRESS, 2).unwrap();
+        assert_eq!(ll.data(), &[0x12, 0x34]);
+        let result = mmu
+            .store_conditional_data(ll.address(), ll, &[0x13, 0x37])
+            .unwrap();
+        assert_eq!(result, StoreConditionalResult::Success);
+        // store successful, data should be written
+        assert_eq!(
+            mmu.data().read(ADDRESS).vec(2).unwrap().as_slice(),
+            &[0x13, 0x37]
+        );
+
+        let ll = mmu.load_linked_data(ADDRESS, 2).unwrap();
+        assert_eq!(ll.data(), &[0x13, 0x37]);
+        mmu.data().write(ADDRESS).bytes(&[0xCA, 0xFE]).unwrap();
+        let result = mmu
+            .store_conditional_data(ll.address(), ll, &[0xBA, 0xBE])
+            .unwrap();
+        assert_eq!(result, StoreConditionalResult::Failure);
+        // not successful, did not write 0xBABE
+        assert_eq!(
+            mmu.data().read(ADDRESS).vec(2).unwrap().as_slice(),
+            &[0xCA, 0xFE]
+        )
+    }
+}

--- a/styx/core/styx-processor/src/memory/memory_region.rs
+++ b/styx/core/styx-processor/src/memory/memory_region.rs
@@ -12,12 +12,13 @@ use styx_errors::UnknownError;
 use styx_sync::sync::Arc;
 
 use getset::CopyGetters;
+use tap::Conv;
 use thiserror::Error;
 use zstd::{decode_all, encode_all};
 
 use super::atomic_word::AtomicWord;
-use super::physical::AtomicMemoryOperationError;
-use super::UnmappedMemoryError;
+use super::physical::{AtomicMemoryOperationError, CompareExchangeError};
+use super::{CompareExchangeResult, UnmappedMemoryError};
 
 #[derive(Debug, Error)]
 #[error("region not 0x{expected_alignment:X} aligned (base: 0x{base:X}, size: 0x{size:X})")]
@@ -604,6 +605,59 @@ impl MemoryRegion {
                 max_size: AtomicWord::WORD_SIZE_BYTES,
             }),
         }
+    }
+
+    /// Perform a Compare Exchange operation on `address`, writing `new` if the current value of those bytes is `new`.
+    pub fn compare_exchange(
+        &self,
+        address: u64,
+        current: &[u8],
+        new: &[u8],
+    ) -> Result<CompareExchangeResult, CompareExchangeError> {
+        if current.len() != new.len() {
+            return Err(CompareExchangeError::MismatchedSizes(
+                current.len(),
+                new.len(),
+            ));
+        }
+        let op_size = current.len();
+        self.address_range_valid(address, op_size as u64, MemoryOperation::Read)
+            .map_err(|e| e.conv::<AtomicMemoryOperationError>())?;
+
+        // the start index into our underlying Vec<u8>
+        let byte_idx: usize = (address - self.base) as usize;
+
+        let word_idx;
+        let inside_word_idx;
+        match align_access::<{ AtomicWord::WORD_SIZE_BYTES }>(byte_idx, current) {
+            // ONLY left or ONLY right
+            // this fits in an word so we are good
+            (_, [], []) | ([], [], _) => {
+                word_idx = byte_idx / AtomicWord::WORD_SIZE_BYTES;
+                // this will be 0 for !right.is_empty()
+                inside_word_idx = byte_idx % AtomicWord::WORD_SIZE_BYTES;
+            }
+            // ONLY middle and ONLY one item
+            // this will fit in an word and is word aligned
+            ([], [_], []) => {
+                word_idx = byte_idx / AtomicWord::WORD_SIZE_BYTES;
+                inside_word_idx = 0;
+            }
+            // any more WILL NOT fit in an word
+            _ => {
+                return Err(AtomicMemoryOperationError::TooLarge {
+                    address,
+                    bytes: current.len(),
+                    max_size: AtomicWord::WORD_SIZE_BYTES,
+                }
+                .into())
+            }
+        }
+
+        // we've checked size and alginement of our compare and swap, this should never Err
+        Ok(self.data.0[word_idx]
+            .compare_exchange(inside_word_idx, current, new)
+            .expect("bug in memory region compare and swap"))
     }
 
     /// # Safety

--- a/styx/core/styx-processor/src/memory/mmu.rs
+++ b/styx/core/styx-processor/src/memory/mmu.rs
@@ -4,8 +4,8 @@ use super::{
     memory_region::{HasRegions, MemoryRegion},
     physical::{MemoryBackend, PhysicalMemoryVariant, Space},
     tlb::DummyTlb,
-    AddRegionError, MemoryArchitecture, MemoryOperation, MemoryOperationError, MemoryPermissions,
-    TlbImpl, TlbTranslateError,
+    AddRegionError, CompareExchangeError, CompareExchangeResult, MemoryArchitecture,
+    MemoryOperation, MemoryOperationError, MemoryPermissions, TlbImpl, TlbTranslateError,
 };
 use crate::{
     cpu::CpuBackend,
@@ -252,6 +252,28 @@ impl Mmu {
         bytes: &mut [u8],
     ) -> Result<(), MemoryOperationError> {
         self.memory.unchecked_read_code(phys_addr, bytes)
+    }
+
+    // ATOMIC
+
+    pub fn compare_exchange_code(
+        &self,
+        physical_address: u64,
+        old: &[u8],
+        new: &[u8],
+    ) -> Result<CompareExchangeResult, CompareExchangeError> {
+        self.memory
+            .compare_exchange_code(physical_address, old, new)
+    }
+
+    pub fn compare_exchange_data(
+        &self,
+        physical_address: u64,
+        old: &[u8],
+        new: &[u8],
+    ) -> Result<CompareExchangeResult, CompareExchangeError> {
+        self.memory
+            .compare_exchange_data(physical_address, old, new)
     }
 
     /// Access data memory using the [memory helper api](crate::memory::helpers).
@@ -681,6 +703,33 @@ mod tests {
         mmu.write_u32_be_phys_data(0x100, 0xdeadbeef).unwrap();
         let data = mmu.data().read(0x100).be().u32().unwrap();
         assert_eq!(data, 0xdeadbeef)
+    }
+
+    /// Simple test of compare exchange in the unmodified and modified case with size=2.
+    #[test]
+    fn test_compare_exchange() {
+        let mut mmu = Mmu::default();
+
+        mmu.write_data(0x1100, &[0x12, 0x34]).unwrap();
+        let result = mmu
+            .compare_exchange_data(0x1100, &[0x99, 0x99], &[0x13, 0x37])
+            .unwrap();
+        assert!(!result.success());
+        // data didn't change because compare exchange failed
+        assert_eq!(
+            mmu.data().read(0x1100).vec(2).unwrap().as_slice(),
+            &[0x12, 0x34]
+        );
+
+        let result = mmu
+            .compare_exchange_data(0x1100, &[0x12, 0x34], &[0x13, 0x37])
+            .unwrap();
+        assert!(result.success());
+        // compare and swap changed data
+        assert_eq!(
+            mmu.data().read(0x1100).vec(2).unwrap().as_slice(),
+            &[0x13, 0x37]
+        );
     }
 
     // todo add tests for virtual addressing once we make a TLB

--- a/styx/core/styx-processor/src/memory/mod.rs
+++ b/styx/core/styx-processor/src/memory/mod.rs
@@ -4,11 +4,165 @@
 //! The [processor core](crate::core) contains the [`Mmu`]. The [`Mmu`] supports traditional mmu
 //! behaviors using the [`TlbImpl`] however it also supports no-translation behavior with the
 //! [`DummyTlb`].
+//!
+//! ## Atomic Operations
+//! In Styx we must faithfully emulate target atomic operations.
+//! While there are many atomic operations that may be implemented by ISAs, we can emulate all of them
+//! using a simple compare and swap operation.
+//! Compare exchange is used as the base operator because our host target architecture x86_64 supports
+//! the operation (`CMPXCHG`) and Rust has stable APIs for compare exchange ([`AtomicU64::compare_exchange()`]).
+//!
+//! [`AtomicU64::compare_exchange()`]: std::sync::atomic::AtomicU64::compare_exchange()
+//!
+//! To perform an arbitrary atomic operation (e.g. Add, Sub, Increment, etc.) use the following steps.
+//!
+//! 1. Load from the address you will modify
+//! 2. Do the operation on the loaded value
+//! 3. Compare exchange using the original loaded value and post operation result
+//! 4. if the compare exchange fails, start again from step 1
+//!
+//! ```
+//! # use styx_processor::memory::Mmu;
+//! # let mut mmu = Mmu::default();
+//! let mut success = false;
+//! while !success {
+//!      // step 1: read initial data
+//!      let mut read_buffer = [0u8; 2];
+//!      mmu.read_data(0x1000, &mut read_buffer).unwrap();
+//!      // step 2: perform operation (`inc` in this case)
+//!      let op_result = (u16::from_le_bytes(read_buffer) + 1).to_le_bytes();
+//!      // step 3: compare exchange with old value
+//!      let compare_exchange_result = mmu.compare_exchange_code(0x1000, &read_buffer, &op_result).unwrap();
+//!      // step 4: repeat if no successful
+//!      success = compare_exchange_result.success();
+//! }
+//! ```
+//!
+//! ### Atomic Operation Restrictions
+//! Styx's atomic operations operate on byte slices
+//! that are sized less than the host word size (assume 8).
+//! The size of the atomic operation must fit into a host word.
+//! For example, a 4 byte atomic operation at address 0 fits within a host word,
+//! but a 4 byte atomic operation at address 6 would not.
+//!
+//! See the Internal Representation section for a visual diagram.
+//!
+//! ### Compare Exchange
+//! The compare exchange (or compare and swap) is an atomic operation used to build other sync primitives.
+//! Briefly, supplied with an `address` as well as `current` and `new` values,
+//! the `new` value will be written if and only if the value at `address` is `current`.
+//! The success or failure of the operation will be reported.
+//!
+//! Styx's implementation of compare exchange follows a similar behavior with a few key differences.
+//!
+//! The first difference is that Styx's compare exchange operation can operate on byte slices
+//! that are sized less than the host word size (assume 8).
+//! Compare exchange operations must follow the restrictions of atomic operations, listed above.
+//!
+//! The second difference is that the compare exchange operation implemented in Styx is weak.
+//! This means that the operation could **fail** despite ``*address == current``.
+//! In practice, the chances of this happening are low.
+//! See the documentation and source code for `AtomicWord` for more information.
+//!
+//! ### Load-Link/Store-Conditional
+//! The Load-link/store-conditional (LL/SC) operation is the primary atomic primitive in RISC architectures.
+//! As such, it is imperative we can emulate this primitive in Styx.
+//!
+//! The behavior of LL/SC is as follows.
+//! An LL instruction loads the value of an `address` from memory and "tags" that `address`.
+//! Later, a SC instruction on the same `address` is used to store a `new` value.
+//! If the memory at `address` has been modified by an atomic instruction since the LL,
+//! the SC will fail.
+//! Otherwise, the operation *can* succeed.
+//! The LL/SC operation is allowed to spuriously fail.
+//!
+//! Users can access a LL/SC api via [`Mmu::load_linked_data()`], [`Mmu::load_linked_code()`],
+//! [`Mmu::store_conditional_data()`] and [`Mmu::store_conditional_code()`].
+//! Is is the caller's responsibility to store a previous load (returned from `load_linked()`)
+//! to be used with the `store_conditional()`.
+//! Styx's implementation of LL/SC follows a similar behavior with a few key differences.
+//!
+//! The first difference is that Styx's LL/SC operation can operate on byte slices
+//! that are sized less than the host word size (assume 8).
+//! LL/SC operations must follow the restrictions of atomic operations, listed above.
+//!
+//! The second difference is that Styx's current implementation will succeed if the
+//! `current` value is unchanged, but the `address` has been modified.
+//! This behavior is subject to the ABA problem.
+//! In firmware emulation, this should rarely be an issue.
+//!
+//! #### LL/SC Addressing Modes
+//! Depending on the emulated ISA, LL/SC operations may reserve based
+//! on the **physical** or **virtual** address.
+//! Since proper reservation is left to the caller, the caller has the option
+//! to track reservations based on virtual or physical addressing.
+//!
+//! However, the `load_linked` and `store_conditional` methods **do** check that the
+//! loaded address matches the store address.
+//! So to load a virtual address but reserve based on a physical address the caller
+//! must use [`Mmu::translate_va()`] then use the physical addressing LL/SC methods.
+//!
+//! The table below shows the methods you should uses for LL/SC with respect to
+//! what addressing mode you are using to Access the memory and to reserve the memory.
+//! All the methods have `_code()` variants.
+//!
+//! | Access/Reservation | Methods to use |
+//! | ------------------ | -------------- |
+//! | Physical/Physical  | [`Mmu::load_linked_data()`]/[`Mmu::store_conditional_data()`] |
+//! | Virtual/Physical   | [`Mmu::translate_va()`] + [`Mmu::load_linked_data()`]/[`Mmu::store_conditional_data()`] |
+//! | Physical/Virtual   | N/A |
+//! | Virtual/Virtual   | [`Mmu::virt_load_linked_data()`]/[`Mmu::virt_store_conditional_data()`] |
+//!
+//! ### Internal Representation
+//!
+//! ```text
+//! === Representation of Memory ===
+//!
+//! AtomicWord based representation
+//! |      AtomicWord       |      AtomicWord       |
+//! |u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|
+//! Byte addressable representation
+//!
+//!
+//! === Acceptable Atomic Operations ===
+//!
+//! Aligned Read/Write
+//!
+//!  4 byte r/w
+//! |-----------|
+//! |           |
+//! -------------------------------------------------
+//! |      AtomicWord       |      AtomicWord       |
+//! |u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|
+//!
+//! Unalgined but fits inside Atomc Word
+//!
+//!        4 byte r/w
+//!       |-----------|
+//!       |           |
+//! -------------------------------------------------
+//! |      AtomicWord       |      AtomicWord       |
+//! |u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|
+//!
+//! === NonAtomic Operations ===
+//!
+//! Small enough, but straddles multiple atomic words
+//!
+//!                    4 byte r/w
+//!                   |-----------|
+//!                   |           |
+//! -------------------------------------------------
+//! |      AtomicWord       |      AtomicWord       |
+//! |u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|u8|
+//!
+//! ```
+//!
 use bitflags::bitflags;
 use derive_more::Display;
 
 mod atomic_word;
 pub mod helpers;
+mod llsc;
 mod mem_arch;
 pub mod memory_region;
 mod mmu;
@@ -17,6 +171,8 @@ pub mod physical;
 mod region;
 mod tlb;
 
+pub use atomic_word::CompareExchangeResult;
+pub use llsc::{StoreConditionalError, StoreConditionalResult};
 pub use mem_arch::MemoryArchitecture;
 pub use memory_region::{
     HasRegions, MemoryRegionFormat, MemoryRegionPerms, MemoryRegionRawData, MemoryRegionSize,
@@ -25,7 +181,10 @@ pub use memory_region::{
 pub use mmu::{
     CodeMemoryOp, DataMemoryOp, MemoryType, Mmu, MmuOpError, SudoCodeMemoryOp, SudoDataMemoryOp,
 };
-pub use physical::{AddRegionError, FromConfigError, MemoryOperationError, UnmappedMemoryError};
+pub use physical::{
+    AddRegionError, AtomicMemoryOperationError, CompareExchangeError, FromConfigError,
+    MemoryOperationError, UnmappedMemoryError,
+};
 pub use tlb::{DummyTlb, FnTlb, TlbImpl, TlbProcessor, TlbTranslateError, TlbTranslateResult};
 
 /// Enum that is used to be explicit in error handling

--- a/styx/core/styx-processor/src/memory/physical.rs
+++ b/styx/core/styx-processor/src/memory/physical.rs
@@ -5,7 +5,7 @@ use styx_errors::anyhow::anyhow;
 use thiserror::Error;
 
 use super::{
-    atomic_word::CompareAndSwapResult, region::RegionStore, MemoryArchitecture, MemoryPermissions,
+    atomic_word::CompareExchangeResult, region::RegionStore, MemoryArchitecture, MemoryPermissions,
 };
 use crate::memory::memory_region::MemoryRegion;
 
@@ -38,6 +38,14 @@ pub enum AtomicMemoryOperationError {
     NotSupported,
     #[error("Atomic memory access failed due to non-atomic reason")]
     NonAtomic(#[from] MemoryOperationError),
+}
+
+#[derive(Error, Debug)]
+pub enum CompareExchangeError {
+    #[error(transparent)]
+    Atomic(#[from] AtomicMemoryOperationError),
+    #[error("mismatched sizes")]
+    MismatchedSizes(usize, usize),
 }
 
 #[derive(Error, Debug)]
@@ -318,26 +326,31 @@ impl MemoryBackend {
 
     // at minimum we need compare and swap on an arbitrary 8 byte.
 
-    /// Performs an atomic arbitrary memory operations.
-    pub fn compare_and_swap_code(
+    /// Compare exchange operation on a segment in code memory.
+    ///
+    /// The `current` and `new` slices must be the same size and be
+    /// < 8 bytes, otherwise this will return `Err()`.
+    pub fn compare_exchange_code(
         &self,
-        _addr: u64,
-        _current: &[u8],
-        _new: &[u8],
-    ) -> Result<CompareAndSwapResult, AtomicMemoryOperationError> {
-        todo!()
+        address: u64,
+        current: &[u8],
+        new: &[u8],
+    ) -> Result<CompareExchangeResult, CompareExchangeError> {
+        self.code_storage().compare_exchange(address, current, new)
     }
 
-    pub fn compare_and_swap_data(
+    /// Compare exchange operation on a segment in data memory.
+    ///
+    /// The `current` and `new` slices must be the same size and be
+    /// < 8 bytes, otherwise this will return `Err()`.
+    pub fn compare_exchange_data(
         &self,
-        _addr: u64,
-        _current: &[u8],
-        _new: &[u8],
-    ) -> Result<CompareAndSwapResult, AtomicMemoryOperationError> {
-        todo!()
+        address: u64,
+        current: &[u8],
+        new: &[u8],
+    ) -> Result<CompareExchangeResult, CompareExchangeError> {
+        self.data_storage().compare_exchange(address, current, new)
     }
-
-    // possible here atomic_add, atomic_inc, etc
 
     /// Reads a contiguous array of code bytes to the buffer `data` starting from `addr`.
     ///

--- a/styx/core/styx-processor/src/memory/region.rs
+++ b/styx/core/styx-processor/src/memory/region.rs
@@ -16,7 +16,10 @@ use region_walker::{
 };
 use styx_errors::UnknownError;
 
-use super::physical::AtomicMemoryOperationError;
+use super::{
+    physical::AtomicMemoryOperationError, CompareExchangeError, CompareExchangeResult,
+    MemoryRegionSize,
+};
 
 /// A region based memory implementation, memory is represented by zero or more
 /// unique, non-overlapping memory regions.
@@ -54,7 +57,6 @@ impl RegionStore {
         .unwrap();
         me
     }
-
     fn check_overlap(&self, base: u64, size: u64) -> bool {
         // ignore anything that would overflow
         if base.checked_add(size).is_none() {
@@ -141,6 +143,27 @@ impl RegionStore {
         } // do nothing if there is no data to write
 
         Ok(())
+    }
+
+    /// Compare exchange operation on a segment in memory.
+    ///
+    /// The `current` and `new` slices must be the same size and be
+    /// < 8 bytes, otherwise this will return `Err()`.
+    pub fn compare_exchange(
+        &self,
+        address: u64,
+        current: &[u8],
+        new: &[u8],
+    ) -> Result<CompareExchangeResult, CompareExchangeError> {
+        let Some(region) = self.regions.iter().find(|r| r.contains(address)) else {
+            return Err(CompareExchangeError::Atomic(
+                AtomicMemoryOperationError::NonAtomic(MemoryOperationError::UnmappedMemory(
+                    UnmappedMemoryError::UnmappedStart(address),
+                )),
+            ));
+        };
+
+        region.compare_exchange(address, current, new)
     }
 
     /// Reads a contiguous array of bytes to the buffer `data`, without checking permissions.

--- a/styx/core/styx-processor/src/processor/builder.rs
+++ b/styx/core/styx-processor/src/processor/builder.rs
@@ -67,7 +67,7 @@ impl<'a> TargetProgramSource<'a> {
 /// // process is owned and must be mutable.
 /// let proc: Processor = ProcessorBuilder::default()
 ///     .with_executor(DefaultExecutor)
-///     .with_backend(Backend::Unicorn)
+///     .with_backend(Backend::Pcode)
 ///     .with_builder(DummyProcessorBuilder)
 ///     .build().unwrap();
 ///


### PR DESCRIPTION
~This is waiting on #155~



Changes
- `Mmu::load_linked_data/code()` and `Mmu::store_conditional_data/code()`
  - Note: the `virt` variants  currently require TLB so thee take `&mut Mmu`. This will require #159  to change.
  - In the future `Mmu` methods will have to take immutable refs
- `AtomicWord::compare_exchange()`
- Lots of documentation in `memory` crates

Closes #157 
Closes #156 