### PR TITLE
Nextest ci profile

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,32 +1,7 @@
-# This is the default config used by nextest. It is embedded in the binary at
-# build time. It may be used as a template for .config/nextest.toml.
-
-[store]
-# The directory under the workspace root at which nextest-related files are
-# written. Profile-specific storage is currently written to dir/<profile-name>.
-dir = "target/nextest"
-
-# This section defines the default nextest profile. Custom profiles are layered
-# on top of the default profile.
 [profile.default]
-# "retries" defines the number of times a test should be retried. If set to a
-# non-zero value, tests that succeed on a subsequent attempt will be marked as
-# non-flaky. Can be overridden through the `--retries` option.
-# Examples
-# * retries = 3
-# * retries = { backoff = "fixed", count = 2, delay = "1s" }
-# * retries = { backoff = "exponential", count = 10, delay = "1s", jitter = true, max-delay = "10s" }
 # added retries to avoid racy ipc cond var when runners
 # or dev stations are under load
 retries = 3
-
-# The number of threads to run tests with. Supported values are either an integer or
-# the string "num-cpus". Can be overridden through the `--test-threads` option.
-test-threads = "num-cpus"
-
-# The number of threads required for each test. This is generally used in overrides to
-# mark certain tests as heavier than others. However, it can also be set as a global parameter.
-threads-required = 1
 
 # Show these test statuses in the output.
 #
@@ -41,51 +16,32 @@ threads-required = 1
 #
 # Each value includes all the values above it; for example, "slow" includes
 # failed and retried tests.
-#
-# Can be overridden through the `--status-level` flag.
-status-level = "skip"
+# Show passed, slow, and failed tests by default.
+status-level = "pass"
+# Don't show passed test at end.
+final-status-level = "slow"
 
-# Similar to status-level, show these test statuses at the end of the run.
-final-status-level = "flaky"
-
-# "failure-output" defines when standard output and standard error for failing tests are produced.
-# Accepted values are
-# * "immediate": output failures as soon as they happen
-# * "final": output failures at the end of the test run
-# * "immediate-final": output failures as soon as they happen and at the end of
-#   the test run; combination of "immediate" and "final"
-# * "never": don't output failures at all
-#
-# For large test suites and CI it is generally useful to use "immediate-final".
-#
-# Can be overridden through the `--failure-output` option.
 failure-output = "immediate-final"
 
-# "success-output" controls production of standard output and standard error on success. This should
-# generally be set to "never".
-success-output = "never"
-
-# Cancel the test run on the first failure. For CI runs, consider setting this
-# to false.
 fail-fast = false
 
 # Treat a test that takes longer than the configured 'period' as slow, and print a message.
 # See <https://nexte.st/book/slow-tests> for more information.
 #
-# Optional: specify the parameter 'terminate-after' with a non-zero integer,
-# which will cause slow tests to be terminated after the specified number of
-# periods have passed.
-# Example: slow-timeout = { period = "60s", terminate-after = 2 }
-slow-timeout = { period = "60s" }
+# Optional: specify the parameter 'terminate-after' which will cause slow tests
+# to be terminated after the specified number of periods have passed.
+slow-timeout = { period = "30s", terminate-after = 4 }
 
 # Treat a test as leaky if after the process is shut down, standard output and standard error
 # aren't closed within this duration.
 #
 # This usually happens in case of a test that creates a child process and lets it inherit those
 # handles, but doesn't clean the child process up (especially when it fails).
-#
-# See <https://nexte.st/book/leaky-tests> for more information.
 leak-timeout = "100ms"
+
+# Test runs will be terminated if they take longer than this timeout.
+# See <https://nexte.st/book/slow-tests> for more information.
+global-timeout = "4m"
 
 [profile.default.junit]
 # Output a JUnit report into the given file inside 'store.dir/<profile-name>'.
@@ -116,3 +72,16 @@ test-threads = 8
 
 [profile.quiet]
 failure-output = "never"
+
+[profile.ci]
+# Show all test statuses in the output.
+# See profile.default entries above for more complete documentaion.
+status-level = "all"
+
+# CI runners are slower than dev machines so we extend slow and global timeouts.
+# See profile.default entries above for more complete documentaion.
+#
+# Treat a test that takes longer than the configured 'period' as slow, and print a message.
+slow-timeout = { period = "60s", terminate-after = 4 }
+# Test runs will be terminated if they take longer than this timeout.
+global-timeout = "10m"

--- a/.github/workflows/cargo-ci.yml
+++ b/.github/workflows/cargo-ci.yml
@@ -88,7 +88,7 @@ jobs:
         sudo apt-get -y update
         sudo apt-get install -y \
           device-tree-compiler
-        just cargo-test
+        just cargo-test --profile ci
 
     # Useful for checking if lock files were not committed after change
     - name: Files are unmodified


### PR DESCRIPTION
Remove comments and default values from default `nextest.toml` so it only contains relevent settings.

Added a CI profile has an extended "slow' timeout. We can add more verbose logging and other configurations here as well. The github actions should use this ci profile.