### PR TITLE
fix: styx-blackfin-sys build error

### DIFF
--- a/styx/generated/styx-blackfin-sys/build.rs
+++ b/styx/generated/styx-blackfin-sys/build.rs
@@ -12,6 +12,9 @@ fn main() {
         // generating struct defs for these types emits the following error:
         // `packed type cannot transitively contain a `#[repr(align)]` type`
         .opaque_type("^(ADI_DMA_DESCRIPTOR_.*)$")
+        // These types fail to be resolved.
+        .opaque_type("ADI_DCB_ENTRY_HDR")
+        .opaque_type("ADI_DEV_BUFFER")
         .derive_default(true)
         // Invalidate the built crate whenever any of the
         // included header files changed.


### PR DESCRIPTION
On my machine (Fedora 44) this was resulting in a build error in bindgen's layout size check, causing them to be generated as opaque. I am not sure why they aren't being resolved, but we can treat them as opaque fields anyway.

I verified that his occurs on a fresh install of Fedora 44 as well. I havn't nailed down the cause but gotta be something with updated packages.