### PR TITLE
fix: unicorn on fedora 44

### DIFF
--- a/styx/core/styx-cpu-unicorn-backend/build.rs
+++ b/styx/core/styx-cpu-unicorn-backend/build.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: BSD-2-Clause
+//! Building unicorn on current Linux distributions fail without linking against libatomic.
+//! This file exists to add libatomic when linking.
+
+fn main() {
+    println!("cargo:rustc-link-lib=atomic");
+}


### PR DESCRIPTION
I think this fixes issues with libatomic on fedora 44. But I don't know if it breaks things with other OSes/distros.